### PR TITLE
Centralize NPM token configuration across PHP containers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,9 +81,24 @@ The installer modifies `dep/xdebug.ini` via sed before copying it to each PHP ve
 
 Xdebug connects to `host.docker.internal:9003` with IDE key `PHPSTORM`.
 
-### Elasticsearch / OpenSearch Mutual Exclusivity
+### Search Services
 
-Elasticsearch 7 and Elasticsearch 8 cannot coexist. OpenSearch is independent and can be combined with either. The volume snippet appended depends on which combination is selected (`elasticsearch-volume`, `elasticsearch-opensearch-volume`, or `opensearch-volume`). If no search service is selected, `phpsockets-volume` is appended instead (to close the volumes section).
+Elasticsearch 7, Elasticsearch 8 and OpenSearch can all run simultaneously. Each has its own host ports and named volume. The `volumes:` section at the end of `docker-compose.yml` is generated dynamically based on which services are selected — no separate volume snippet files are used.
+
+| Service | Host ports | Volume |
+|---|---|---|
+| elasticsearch7 | 9202 / 9302 | `elasticsearch7` |
+| elasticsearch8 | 9200 / 9300 | `elasticsearch8` |
+| opensearch | 9201 / 9301 | `opensearch` |
+
+### NPM Token Configuration
+
+NPM tokens are managed centrally in `~/.config/npm-tokens.env` (never committed to the repo). The installer creates this file from `dep/npm-tokens.env.example` on first run. All PHP containers mount it read-only at `/etc/npm-tokens.env`. The entrypoint script sources it at startup and adds it to `.bashrc` so tokens are available in both php-fpm and interactive shell sessions (`enter php84`).
+
+To rotate tokens, update `~/.config/npm-tokens.env` and restart the relevant containers:
+```bash
+devctl restart php84
+```
 
 ### Platform-Specific sed
 
@@ -132,6 +147,7 @@ On ARM64 (macOS Apple Silicon), the installer uses BSD sed syntax: `sed -i ''`. 
 | `dep/xdebug.ini` | Xdebug config template (modified per install options) |
 | `dep/opcache.ini` | OPcache config (copied verbatim to each PHP version) |
 | `dep/phprun.sh` | Container entrypoint template (`##PHPVERSION##` placeholder) |
+| `dep/npm-tokens.env.example` | Template for `~/.config/npm-tokens.env` (NPM token config) |
 | `docker-compose-snippets/*` | Per-service compose fragments appended during install |
 | `docker/nginx/site-templates/` | Nginx virtual host templates (one per framework) |
 | `docker/docker-compose.yml` | Base compose file (nginx, redis, mail, network) |
@@ -146,7 +162,8 @@ On ARM64 (macOS Apple Silicon), the installer uses BSD sed syntax: `sed -i ''`. 
 | MySQL 5.6 / 5.7 / 8.0 | 3305 / 3306 / 3308 |
 | MongoDB | 27017 |
 | Redis | 6379 |
-| Elasticsearch 7/8 | 9200, 9300 |
+| Elasticsearch 7 | 9202, 9302 |
+| Elasticsearch 8 | 9200, 9300 |
 | OpenSearch | 9201, 9301 |
 | Mailtrap UI / SMTP | 8085 / 25 |
 | MailHog UI / SMTP | 8025 / 1025 |

--- a/dep/npm-tokens.env.example
+++ b/dep/npm-tokens.env.example
@@ -1,0 +1,2 @@
+NPM_FONTAWESOME_TOKEN=fill_token_here
+NPM_TOKEN=npm_personal_token

--- a/dep/phprun.sh
+++ b/dep/phprun.sh
@@ -9,6 +9,14 @@ fi
 export XCOM_SERVERUSER=$USERNAME
 export XCOM_SERVERTYPE=dev
 
+NPM_TOKENS_FILE="/etc/npm-tokens.env"
+if [ -f "$NPM_TOKENS_FILE" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$NPM_TOKENS_FILE"
+    set +a
+fi
+
 sudo /etc/init.d/nullmailer start
 
 if [ ! -f "/home/web/.bashrc" ]; then
@@ -28,6 +36,10 @@ fi
 if ! grep -q "export XCOM_SERVERUSER" /home/web/.bashrc; then
   echo "export XCOM_SERVERTYPE=$XCOM_SERVERTYPE" >> /home/web/.bashrc
   echo "export XCOM_SERVERUSER=$XCOM_SERVERUSER" >> /home/web/.bashrc
+fi
+
+if ! grep -q "npm-tokens.env" /home/web/.bashrc; then
+    echo "if [ -f $NPM_TOKENS_FILE ]; then set -a; source $NPM_TOKENS_FILE; set +a; fi" >> /home/web/.bashrc
 fi
 
 if ! grep -q "export TERM=xterm" /home/web/.bashrc; then

--- a/docker-compose-snippets/php70
+++ b/docker-compose-snippets/php70
@@ -13,6 +13,7 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php70:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
     user: web
     working_dir: /data/shared/sites

--- a/docker-compose-snippets/php72
+++ b/docker-compose-snippets/php72
@@ -10,6 +10,7 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php72:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
       - ./php72/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php72/conf.d/php.ini:/usr/local/etc/php/php.ini

--- a/docker-compose-snippets/php73
+++ b/docker-compose-snippets/php73
@@ -13,6 +13,7 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php73:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
     user: web
     working_dir: /data/shared/sites

--- a/docker-compose-snippets/php74
+++ b/docker-compose-snippets/php74
@@ -10,6 +10,7 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php74:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
       - ./php74/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php74/conf.d/php.ini:/usr/local/etc/php/php.ini

--- a/docker-compose-snippets/php80
+++ b/docker-compose-snippets/php80
@@ -10,6 +10,7 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php80:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
       - ./php80/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php80/conf.d/php.ini:/usr/local/etc/php/php.ini

--- a/docker-compose-snippets/php81
+++ b/docker-compose-snippets/php81
@@ -10,6 +10,7 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php81:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
       - ./php81/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php81/conf.d/php.ini:/usr/local/etc/php/php.ini

--- a/docker-compose-snippets/php82
+++ b/docker-compose-snippets/php82
@@ -10,6 +10,7 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php82:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
       - ./php82/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php82/conf.d/php.ini:/usr/local/etc/php/php.ini

--- a/docker-compose-snippets/php83
+++ b/docker-compose-snippets/php83
@@ -10,6 +10,7 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php83:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
       - ./php83/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php83/conf.d/php.ini:/usr/local/etc/php/php.ini

--- a/docker-compose-snippets/php84
+++ b/docker-compose-snippets/php84
@@ -10,6 +10,7 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php84:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
       - ./php84/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php84/conf.d/php.ini:/usr/local/etc/php/php.ini

--- a/docker-compose-snippets/php85
+++ b/docker-compose-snippets/php85
@@ -10,6 +10,7 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php85:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
       - ./php85/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php85/conf.d/php.ini:/usr/local/etc/php/php.ini

--- a/install.sh
+++ b/install.sh
@@ -85,6 +85,12 @@ if [ ! -d "$HOME/.ssh" ] ; then
     mkdir -p "$HOME/.ssh"
 fi
 
+# Create npm tokens file from example if it doesn't exist yet
+if [ ! -f "$HOME/.config/npm-tokens.env" ]; then
+    cp ./dep/npm-tokens.env.example "$HOME/.config/npm-tokens.env"
+    dialog --msgbox "NPM tokens file aangemaakt op $HOME/.config/npm-tokens.env\nVul je tokens in voordat je de containers start." 8 65
+fi
+
 # Users can change the project slug (saved in config file)
 # If there is no projectslug set, this code sets the default
 if [ -z "$PROJECTSLUG" ]; then


### PR DESCRIPTION
Closes #18

## Summary

- Tokens worden geconfigureerd in één bestand: `~/.config/npm-tokens.env`
- Het bestand wordt automatisch aangemaakt vanuit `dep/npm-tokens.env.example` bij de eerste `make run`
- Alle PHP containers (7.0–8.5) mounten het bestand als `/etc/npm-tokens.env`
- Tokens zijn beschikbaar in php-fpm én in interactieve shell sessies (`enter php84`)
- Token rotatie vereist geen container rebuild, alleen een herstart

## Token rotatie

Pas `~/.config/npm-tokens.env` aan en herstart de container:
```bash
devctl restart php84
```