### PR TITLE
Add devctl support from within PHP containers

### DIFF
--- a/dep/devctl-container.sh
+++ b/dep/devctl-container.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Container-side devctl — subset of host devctl for use inside PHP containers.
+# Requires Docker socket mounted at /var/run/docker.sock.
+
+case "$1" in
+    reload)
+        NGINX=$(docker ps -qf "name=nginx" --filter "status=running" | head -1)
+        [ -z "$NGINX" ] && echo "nginx container not found" && exit 1
+        docker exec "$NGINX" nginx -s reload && echo "nginx reloaded"
+        ;;
+    flushredis)
+        REDIS=$(docker ps -qf "name=redis" --filter "status=running" | head -1)
+        [ -z "$REDIS" ] && echo "redis container not found" && exit 1
+        if [ -n "$2" ]; then
+            docker exec "$REDIS" redis-cli -n "$2" flushdb
+        else
+            docker exec "$REDIS" redis-cli flushall
+        fi
+        ;;
+    restart)
+        [ -z "$2" ] && echo "Usage: devctl restart <container>" && exit 1
+        docker restart "$2"
+        ;;
+    ps|status)
+        docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+        ;;
+    tail)
+        [ -z "$2" ] && echo "Usage: devctl tail <container>" && exit 1
+        docker logs -f "$2"
+        ;;
+    *)
+        echo "Container devctl — available commands:"
+        echo "  reload              Reload nginx (picks up config changes)"
+        echo "  flushredis [db]     Flush Redis cache"
+        echo "  restart <container> Restart a container"
+        echo "  tail <container>    Follow container logs"
+        echo "  ps / status         Show running containers"
+        ;;
+esac

--- a/dep/phprun.sh
+++ b/dep/phprun.sh
@@ -33,6 +33,21 @@ if [ ! -d "$BIN_DIR" ]; then
     fi
 fi
 
+# install docker CLI for container-side devctl (uses mounted Docker socket)
+if [ ! -f "$BIN_DIR/docker" ]; then
+    ARCH=$(uname -m)
+    DOCKER_ARCH="x86_64"
+    [ "$ARCH" = "aarch64" ] && DOCKER_ARCH="aarch64"
+    curl -fsSL "https://download.docker.com/linux/static/stable/${DOCKER_ARCH}/docker-27.5.1.tgz" \
+        | tar -xz -C "$BIN_DIR" --strip-components=1 docker/docker
+fi
+
+# install container-side devctl wrapper
+if [ ! -f /usr/local/bin/devctl ]; then
+    sudo cp /etc/devctl-container.sh /usr/local/bin/devctl
+    sudo chmod +x /usr/local/bin/devctl
+fi
+
 if ! grep -q "export XCOM_SERVERUSER" /home/web/.bashrc; then
   echo "export XCOM_SERVERTYPE=$XCOM_SERVERTYPE" >> /home/web/.bashrc
   echo "export XCOM_SERVERUSER=$XCOM_SERVERUSER" >> /home/web/.bashrc

--- a/docker-compose-snippets/php70
+++ b/docker-compose-snippets/php70
@@ -13,8 +13,10 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php70:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
+      - /var/run/docker.sock:/var/run/docker.sock
     user: web
     working_dir: /data/shared/sites
     entrypoint: /run.sh

--- a/docker-compose-snippets/php72
+++ b/docker-compose-snippets/php72
@@ -10,8 +10,10 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php72:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
+      - /var/run/docker.sock:/var/run/docker.sock
       - ./php72/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php72/conf.d/php.ini:/usr/local/etc/php/php.ini
       - ./php72/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/docker-compose-snippets/php73
+++ b/docker-compose-snippets/php73
@@ -13,8 +13,10 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php73:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
+      - /var/run/docker.sock:/var/run/docker.sock
     user: web
     working_dir: /data/shared/sites
     entrypoint: /run.sh

--- a/docker-compose-snippets/php74
+++ b/docker-compose-snippets/php74
@@ -10,8 +10,10 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php74:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
+      - /var/run/docker.sock:/var/run/docker.sock
       - ./php74/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php74/conf.d/php.ini:/usr/local/etc/php/php.ini
       - ./php74/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/docker-compose-snippets/php80
+++ b/docker-compose-snippets/php80
@@ -10,8 +10,10 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php80:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
+      - /var/run/docker.sock:/var/run/docker.sock
       - ./php80/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php80/conf.d/php.ini:/usr/local/etc/php/php.ini
       - ./php80/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/docker-compose-snippets/php81
+++ b/docker-compose-snippets/php81
@@ -10,8 +10,10 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php81:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
+      - /var/run/docker.sock:/var/run/docker.sock
       - ./php81/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php81/conf.d/php.ini:/usr/local/etc/php/php.ini
       - ./php81/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/docker-compose-snippets/php82
+++ b/docker-compose-snippets/php82
@@ -10,8 +10,10 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php82:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
+      - /var/run/docker.sock:/var/run/docker.sock
       - ./php82/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php82/conf.d/php.ini:/usr/local/etc/php/php.ini
       - ./php82/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/docker-compose-snippets/php83
+++ b/docker-compose-snippets/php83
@@ -10,8 +10,10 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php83:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
+      - /var/run/docker.sock:/var/run/docker.sock
       - ./php83/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php83/conf.d/php.ini:/usr/local/etc/php/php.ini
       - ./php83/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/docker-compose-snippets/php84
+++ b/docker-compose-snippets/php84
@@ -10,8 +10,10 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php84:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
+      - /var/run/docker.sock:/var/run/docker.sock
       - ./php84/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php84/conf.d/php.ini:/usr/local/etc/php/php.ini
       - ./php84/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/docker-compose-snippets/php85
+++ b/docker-compose-snippets/php85
@@ -10,8 +10,10 @@
       - installdirectory/data/shared/media:/data/shared/media
       - installdirectory/data/home/php85:/home/web
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
+      - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
       - ~/.ssh:/home/web/.ssh
+      - /var/run/docker.sock:/var/run/docker.sock
       - ./php85/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf
       - ./php85/conf.d/php.ini:/usr/local/etc/php/php.ini
       - ./php85/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/install.sh
+++ b/install.sh
@@ -105,10 +105,12 @@ setup_devctl () {
     cp dep/devctl.sh "$HOME/.local/bin/devctl"
     cp dep/enter.sh "$HOME/.local/bin/enter"
     cp dep/nginx-sites.sh "$HOME/.local/bin/nginx-sites"
+    cp dep/devctl-container.sh "$installdir/docker/devctl-container.sh"
     sed -i -e 's:installdirectory:'"$installdir"':g' "$HOME/.local/bin/devctl"
     chmod +x "$HOME/.local/bin/devctl"
     chmod +x "$HOME/.local/bin/enter"
     chmod +x "$HOME/.local/bin/nginx-sites.sh"
+    chmod +x "$installdir/docker/devctl-container.sh"
 }
 
 # Function to setup gitconfig which is later copied to selected php containers


### PR DESCRIPTION
## Summary

- Docker socket (`/var/run/docker.sock`) wordt gemount in alle PHP containers
- Bij eerste containerstart wordt de docker CLI automatisch gedownload
- Nieuw bestand `dep/devctl-container.sh` biedt een subset van `devctl` aan vanuit de container:

| Command | Effect |
|---|---|
| `devctl reload` | Reload nginx config |
| `devctl flushredis [db]` | Flush Redis |
| `devctl restart <container>` | Herstart container |
| `devctl tail <container>` | Volg container logs |
| `devctl ps / status` | Toon draaiende containers |

## Gebruikersinstallatie

De `/devenv` Claude Code skill staat los van dit project en is geïnstalleerd op `~/.claude/skills/devenv/SKILL.md`.