### PR TITLE
Add Claude Code to PHP containers

### DIFF
--- a/dep/phprun.sh
+++ b/dep/phprun.sh
@@ -109,6 +109,7 @@ if [ ! -f "$NODE_DIR/bin/node" ]; then
     fi
 fi
 if [ -f "$NODE_DIR/bin/npm" ] && [ ! -f "$NODE_DIR/bin/claude" ]; then
+    export PATH="$NODE_DIR/bin:$PATH"
     "$NODE_DIR/bin/npm" install -g @anthropic-ai/claude-code --prefix "$NODE_DIR"
     chown -R web:web "$NODE_DIR"
 fi

--- a/dep/phprun.sh
+++ b/dep/phprun.sh
@@ -95,4 +95,22 @@ if [ ! -d "/home/web/.nvm" ]; then
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
 fi
 
+# Install Node.js LTS for Claude Code (persistent — /home/web is a bind mount)
+NODE_DIR="/home/web/.node_lts"
+if [ ! -f "$NODE_DIR/bin/node" ]; then
+    ARCH=$(uname -m)
+    NODE_ARCH="x64"
+    [ "$ARCH" = "aarch64" ] && NODE_ARCH="arm64"
+    curl -fsSL "https://nodejs.org/dist/v22.15.0/node-v22.15.0-linux-${NODE_ARCH}.tar.xz" \
+        | tar -xJ -C "/home/web" --one-top-level=.node_lts --strip-components=1
+    chown -R web:web "$NODE_DIR"
+    if ! grep -q ".node_lts/bin" /home/web/.bashrc; then
+        echo 'export PATH=$HOME/.node_lts/bin:$PATH' >> /home/web/.bashrc
+    fi
+fi
+if [ -f "$NODE_DIR/bin/npm" ] && [ ! -f "$NODE_DIR/bin/claude" ]; then
+    "$NODE_DIR/bin/npm" install -g @anthropic-ai/claude-code --prefix "$NODE_DIR"
+    chown -R web:web "$NODE_DIR"
+fi
+
 sudo php-fpm -R

--- a/docker-compose-snippets/php70
+++ b/docker-compose-snippets/php70
@@ -15,6 +15,7 @@
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
       - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
+      - ~/.claude:/home/web/.claude
       - ~/.ssh:/home/web/.ssh
       - /var/run/docker.sock:/var/run/docker.sock
     user: web

--- a/docker-compose-snippets/php72
+++ b/docker-compose-snippets/php72
@@ -12,6 +12,7 @@
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
       - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
+      - ~/.claude:/home/web/.claude
       - ~/.ssh:/home/web/.ssh
       - /var/run/docker.sock:/var/run/docker.sock
       - ./php72/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf

--- a/docker-compose-snippets/php73
+++ b/docker-compose-snippets/php73
@@ -15,6 +15,7 @@
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
       - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
+      - ~/.claude:/home/web/.claude
       - ~/.ssh:/home/web/.ssh
       - /var/run/docker.sock:/var/run/docker.sock
     user: web

--- a/docker-compose-snippets/php74
+++ b/docker-compose-snippets/php74
@@ -12,6 +12,7 @@
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
       - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
+      - ~/.claude:/home/web/.claude
       - ~/.ssh:/home/web/.ssh
       - /var/run/docker.sock:/var/run/docker.sock
       - ./php74/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf

--- a/docker-compose-snippets/php80
+++ b/docker-compose-snippets/php80
@@ -12,6 +12,7 @@
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
       - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
+      - ~/.claude:/home/web/.claude
       - ~/.ssh:/home/web/.ssh
       - /var/run/docker.sock:/var/run/docker.sock
       - ./php80/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf

--- a/docker-compose-snippets/php81
+++ b/docker-compose-snippets/php81
@@ -12,6 +12,7 @@
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
       - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
+      - ~/.claude:/home/web/.claude
       - ~/.ssh:/home/web/.ssh
       - /var/run/docker.sock:/var/run/docker.sock
       - ./php81/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf

--- a/docker-compose-snippets/php82
+++ b/docker-compose-snippets/php82
@@ -12,6 +12,7 @@
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
       - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
+      - ~/.claude:/home/web/.claude
       - ~/.ssh:/home/web/.ssh
       - /var/run/docker.sock:/var/run/docker.sock
       - ./php82/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf

--- a/docker-compose-snippets/php83
+++ b/docker-compose-snippets/php83
@@ -12,6 +12,7 @@
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
       - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
+      - ~/.claude:/home/web/.claude
       - ~/.ssh:/home/web/.ssh
       - /var/run/docker.sock:/var/run/docker.sock
       - ./php83/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf

--- a/docker-compose-snippets/php84
+++ b/docker-compose-snippets/php84
@@ -12,6 +12,7 @@
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
       - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
+      - ~/.claude:/home/web/.claude
       - ~/.ssh:/home/web/.ssh
       - /var/run/docker.sock:/var/run/docker.sock
       - ./php84/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf

--- a/docker-compose-snippets/php85
+++ b/docker-compose-snippets/php85
@@ -12,6 +12,7 @@
       - ~/.config/docker-setup.config:/etc/docker-setup.config:ro
       - installdirectory/docker/devctl-container.sh:/etc/devctl-container.sh:ro
       - ~/.config/npm-tokens.env:/etc/npm-tokens.env:ro
+      - ~/.claude:/home/web/.claude
       - ~/.ssh:/home/web/.ssh
       - /var/run/docker.sock:/var/run/docker.sock
       - ./php85/php-fpm.d/zz-docker.conf:/usr/local/etc/php-fpm.d/zz-docker.conf

--- a/docker/php85/Dockerfile
+++ b/docker/php85/Dockerfile
@@ -23,7 +23,7 @@ RUN pecl install mongodb
 RUN pecl install imagick
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg
 RUN docker-php-ext-install -j$(nproc) gd pdo_mysql mysqli mbstring bcmath calendar exif ffi fileinfo gettext \
-    intl soap zip xsl sockets
+    intl soap zip xsl sockets ftp
 # other extensions we dont need right now
 # mysqli pcntl hmop sockets sysvmsg sysvmsg sysvshm sysvsem
 


### PR DESCRIPTION
## Summary

- Adds `~/.claude` host mount to all PHP containers so settings, memory and conversation history are shared with the host
- Installs Node.js LTS v22 and `@anthropic-ai/claude-code` in `phprun.sh` — persists across restarts via the existing `/home/web` bind mount
- Adds `ext-ftp` back to the PHP 8.5 Dockerfile (was incorrectly removed)

## Notes

- `/home/web` is already a bind mount per PHP version, so Node.js and Claude Code survive container restarts
- On first startup after recreate, Node.js is downloaded and `claude-code` is installed automatically
- Existing project conversation history from before the mount was added can be recovered from `data/home/phpXX/.claude/projects/`

## Test plan

- [ ] `devctl recreate php84` → `enter php84` → `claude --version`
- [ ] Verify `~/.claude/projects/` is shared between host and container
- [ ] Verify `ext-ftp` is available: `php -r "echo extension_loaded('ftp');"`